### PR TITLE
fix: stop reporting every Libro verification error as an unreachable chain

### DIFF
--- a/libro/chrome-extension/src/content.ts
+++ b/libro/chrome-extension/src/content.ts
@@ -1,4 +1,4 @@
-import type { LibroCandidate, LibroVerificationResult } from './shared'
+import { isIndeterminateStatus, type LibroCandidate, type LibroVerificationResult } from './shared'
 import {
   captureCurrentText,
   replaceCapture,
@@ -265,8 +265,8 @@ function libroTextTagHashMatches(declaredHash: string, signalHash: string): bool
 
   function stateClass(status: LibroVerificationResult['status']): string {
     if (status === 'verified') return 'libro-extension-verified'
-    if (status === 'network_unavailable' || status === 'manifest_missing') return 'libro-extension-unknown'
     if (status === 'stale') return 'libro-extension-stale'
+    if (isIndeterminateStatus(status)) return 'libro-extension-unknown'
     return 'libro-extension-warning'
   }
 
@@ -285,7 +285,7 @@ function libroTextTagHashMatches(declaredHash: string, signalHash: string): bool
     const badge = document.createElement('span')
     badge.className = result.status === 'verified'
       ? 'verified'
-      : result.status === 'network_unavailable' || result.status === 'manifest_missing' || result.status === 'stale'
+      : isIndeterminateStatus(result.status)
         ? 'unknown'
         : 'warning'
     badge.textContent = `Libro · ${result.label}`

--- a/libro/chrome-extension/src/popup.css
+++ b/libro/chrome-extension/src/popup.css
@@ -16,8 +16,8 @@ header p { margin: 1px 0 0; color: #71717a; font-size: 12px; }
 .results { display: grid; gap: 8px; margin-top: 10px; }
 .result { border: 1px solid #d4d4d8; border-left-width: 4px; border-radius: 8px; background: white; padding: 9px 10px; }
 .result.verified { border-left-color: #16a34a; }
-.result.network_unavailable, .result.stale { border-left-color: #d97706; }
-.result:not(.verified):not(.network_unavailable):not(.stale) { border-left-color: #dc2626; }
+.result.network_unavailable, .result.registration_unconfirmed, .result.stale { border-left-color: #d97706; }
+.result:not(.verified):not(.network_unavailable):not(.registration_unconfirmed):not(.stale) { border-left-color: #dc2626; }
 .result-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
 .result-heading code { color: #71717a; font-size: 11px; }
 .metadata { margin-top: 2px; color: #4f46e5; font-size: 12px; }

--- a/libro/chrome-extension/src/service-worker.ts
+++ b/libro/chrome-extension/src/service-worker.ts
@@ -81,7 +81,7 @@ async function activeTabId(): Promise<number> {
 
 function setToolbarBadge(results: LibroVerificationResult[]): void {
   const verified = results.filter((item) => item.status === 'verified').length
-  const hasProblems = results.some((item) => !['verified', 'network_unavailable'].includes(item.status))
+  const hasProblems = results.some((item) => !['verified', 'registration_unconfirmed', 'network_unavailable'].includes(item.status))
   const text = verified > 0 ? String(verified) : hasProblems ? '!' : results.length === 0 ? '0' : '?'
   const color = verified > 0 ? '#15803d' : hasProblems ? '#b91c1c' : '#71717a'
   chrome.action.setBadgeBackgroundColor({ color }).catch(() => undefined)

--- a/libro/chrome-extension/src/shared.ts
+++ b/libro/chrome-extension/src/shared.ts
@@ -20,8 +20,24 @@ export type LibroVerificationStatus =
   | 'manifest_missing'
   | 'unsupported_registry'
   | 'not_registered'
+  | 'registration_unconfirmed'
   | 'network_unavailable'
   | 'stale'
+
+/**
+ * Statuses that mean "we could not decide", as opposed to "this block is wrong".
+ * These render amber rather than red.
+ */
+const INDETERMINATE_STATUSES: ReadonlySet<LibroVerificationStatus> = new Set([
+  'manifest_missing',
+  'registration_unconfirmed',
+  'network_unavailable',
+  'stale',
+])
+
+export function isIndeterminateStatus(status: LibroVerificationStatus): boolean {
+  return INDETERMINATE_STATUSES.has(status)
+}
 
 export type LibroVerificationResult = {
   blockId: string

--- a/libro/chrome-extension/src/verifier.test.ts
+++ b/libro/chrome-extension/src/verifier.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   LibroNotRegisteredError,
   LibroRegistrationMismatchError,
+  LibroRegistrationUnconfirmedError,
   actionHashToHex,
   canonicalPublicationSignal,
   hashPublicationSignal,
@@ -126,7 +127,18 @@ describe('extension candidate verification', () => {
       .resolves.toMatchObject({ status: 'not_registered' })
     await expect(verifyCandidate(candidate(), async () => { throw new LibroRegistrationMismatchError('wrong receipt') }))
       .resolves.toMatchObject({ status: 'invalid_manifest' })
+    await expect(verifyCandidate(candidate(), async () => { throw new LibroRegistrationUnconfirmedError('no receipt') }))
+      .resolves.toMatchObject({ status: 'registration_unconfirmed' })
     await expect(verifyCandidate(candidate(), async () => { throw new Error('offline') }))
       .resolves.toMatchObject({ status: 'network_unavailable' })
+  })
+
+  it('reports the underlying cause instead of swallowing unclassified failures', async () => {
+    const result = await verifyCandidate(candidate(), async () => {
+      throw new Error('HTTP request failed: 429 Too Many Requests\nDocs: https://viem.sh\nVersion: viem@2')
+    })
+    expect(result.status).toBe('network_unavailable')
+    expect(result.detail).toContain('429 Too Many Requests')
+    expect(result.detail).not.toContain('Docs:')
   })
 })

--- a/libro/chrome-extension/src/verifier.ts
+++ b/libro/chrome-extension/src/verifier.ts
@@ -1,6 +1,7 @@
 import {
   LibroNotRegisteredError,
   LibroRegistrationMismatchError,
+  LibroRegistrationUnconfirmedError,
   LibroUnsupportedRegistryError,
   assertLibroManifestLocalIntegrity,
   extractReadableText,
@@ -23,8 +24,17 @@ const LABELS = {
   manifest_missing: 'Manifest missing',
   unsupported_registry: 'Unsupported registry',
   not_registered: 'Not registered',
+  registration_unconfirmed: 'Registration unconfirmed',
   network_unavailable: 'Network unavailable',
 } as const
+
+/** viem errors carry multi-line docs footers; keep only the headline for the badge tooltip. */
+function summarizeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  const headline = message.split('\n', 1)[0].trim()
+  if (!headline) return error instanceof Error ? error.name : 'unknown error'
+  return headline.length > 140 ? `${headline.slice(0, 139)}…` : headline
+}
 
 function urlsMatch(left: string, right: string): boolean {
   try {
@@ -123,6 +133,27 @@ export async function verifyCandidate(
     if (error instanceof LibroRegistrationMismatchError) {
       return result(candidate, 'invalid_manifest', error.message, manifest)
     }
-    return result(candidate, 'network_unavailable', 'World Chain could not be reached; verification is unknown', manifest)
+    if (error instanceof LibroRegistrationUnconfirmedError) {
+      return result(
+        candidate,
+        'registration_unconfirmed',
+        'The signal is registered, but World Chain has no record of the transaction this manifest cites',
+        manifest
+      )
+    }
+    // Everything else lands here, so surface the cause rather than reporting every
+    // unclassified failure as an unreachable network.
+    console.warn('[libro] on-chain verification failed', {
+      blockId: candidate.blockId,
+      signalHash: manifest.registration.signal_hash,
+      transactionHash: manifest.registration.transaction_hash,
+      error,
+    })
+    return result(
+      candidate,
+      'network_unavailable',
+      `World Chain could not be reached; verification is unknown (${summarizeError(error)})`,
+      manifest
+    )
   }
 }

--- a/libro/core/src/index.ts
+++ b/libro/core/src/index.ts
@@ -9,6 +9,7 @@ import {
   keccak256,
   parseEventLogs,
   toBytes,
+  TransactionReceiptNotFoundError,
   type Abi,
   type Address,
   type Hex,
@@ -372,6 +373,8 @@ export function isApprovedLibroRegistry(chainId: number, address: string): boole
 export class LibroUnsupportedRegistryError extends Error {}
 export class LibroNotRegisteredError extends Error {}
 export class LibroRegistrationMismatchError extends Error {}
+/** The signal is registered, but the transaction the manifest cites cannot be found on chain. */
+export class LibroRegistrationUnconfirmedError extends Error {}
 
 export function assertLibroManifestLocalIntegrity(value: unknown): LibroEmbedManifestV1 {
   const manifest = parseLibroEmbedManifest(value)
@@ -429,7 +432,15 @@ export async function verifyLibroManifestOnChain(
   })
   if (!registered) throw new LibroNotRegisteredError('Signal is not registered')
 
-  const receipt = await client.getTransactionReceipt({ hash: manifest.registration.transaction_hash })
+  let receipt
+  try {
+    receipt = await client.getTransactionReceipt({ hash: manifest.registration.transaction_hash })
+  } catch (error) {
+    if (error instanceof TransactionReceiptNotFoundError) {
+      throw new LibroRegistrationUnconfirmedError('Registration transaction was not found on chain')
+    }
+    throw error
+  }
   if (receipt.status !== 'success') {
     throw new LibroRegistrationMismatchError('Registration transaction was not successful')
   }


### PR DESCRIPTION
The extension's verifier funnelled any error that was not one of three typed Libro errors into `network_unavailable`, showing "World Chain could not be reached; verification is unknown" and discarding the cause. A missing transaction receipt, an RPC 429, or an aborted service worker all looked identical, and nothing was logged.

Split the receipt case out and surface the rest:

- Add `LibroRegistrationUnconfirmedError` in @libro/core and raise it when `getTransactionReceipt` throws `TransactionReceiptNotFoundError`, instead of letting the raw viem error escape.
- Map it to a new `registration_unconfirmed` status: the signal is registered, but the chain has no record of the transaction the manifest cites. Treated as indeterminate rather than a failure, since `signal_hash` is already bound to the publication content, so an unresolvable tx hash cannot forge authorship.
- Log the underlying error with block, signal hash, and transaction hash, and append its headline to the visible detail. `summarizeError` keeps the first line only, capped at 140 chars, so viem's multi-line docs footer stays out of the badge tooltip.
- Extract `isIndeterminateStatus()` into shared.ts; the amber/red split was duplicated in two places in content.ts and a `:not()` chain in popup.css.


Claude-Session: https://claude.ai/code/session_01XFJF9qJyBr12z3bgQ6B5AE