### PR TITLE
fix: drop Vite modulepreload polyfill from the Chrome extension build

### DIFF
--- a/libro/chrome-extension/vite.config.ts
+++ b/libro/chrome-extension/vite.config.ts
@@ -48,6 +48,9 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: outputDirectory,
       emptyOutDir: true,
+      // Chrome supports modulepreload natively, so the polyfill chunk and its
+      // preload links are dead weight and warn on chrome-extension:// pages.
+      modulePreload: false,
       rollupOptions: {
         input: {
           popup: resolve(import.meta.dirname, 'popup.html'),


### PR DESCRIPTION
The extension build emitted a shared modulepreload-polyfill chunk plus a <link rel="modulepreload"> in popup.html, sidepanel.html, and options.html. Chrome supports modulepreload natively, so the polyfill returned immediately without doing anything, and on chrome-extension:// pages the speculative preload was discarded as a cross-world resource mismatch, logging two console warnings per page load.

Set build.modulePreload to false so neither the chunk nor the preload links are emitted. The content script is an IIFE lib build and is unaffected.


Claude-Session: https://claude.ai/code/session_01NnYchRR2KxkjskGfHKnPCT